### PR TITLE
Upgrade to miglayout-swt-5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>26.0.0</version>
+		<version>27.0.1</version>
 		<relativePath />
 	</parent>
 
@@ -86,6 +86,7 @@ Wisconsin-Madison.</license.copyrightOwners>
 		<license.projectName>SciJava UI components for Eclipse SWT.</license.projectName>
 
 		<swt.version>3.0m7</swt.version>
+		<miglayout-swt.version>5.2</miglayout-swt.version>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
@@ -101,9 +102,8 @@ Wisconsin-Madison.</license.copyrightOwners>
 		<!-- Third-party dependencies -->
 		<dependency>
 			<groupId>com.miglayout</groupId>
-			<artifactId>miglayout</artifactId>
-			<version>${miglayout.version}</version>
-			<classifier>swt</classifier>
+			<artifactId>miglayout-swt</artifactId>
+			<version>${miglayout-swt.version}</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
The version pinning can be removed once we have a `pom-scijava` release managing this version (see https://github.com/scijava/pom-scijava/pull/97).